### PR TITLE
add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Cog Implementation of ControlNet Tile 
 
+[![Try a demo on Replicate](https://replicate.com/batouresearch/magic-image-refiner/badge)](https://replicate.com/batouresearch/magic-image-refiner)
+
 This is an implementation of the [Diffusers ControlNet](https://huggingface.co/blog/controlnet) as a Cog model. [Cog](https://github.com/replicate/cog) packages machine learning models as standard containers.


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.